### PR TITLE
build(pods): lock NVActivityIndicatorView to version 4.x

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ target 'iosvirtualassistantapp' do
 
     pod 'MessageKit', '~> 0.13'
     pod 'IBMWatsonAssistantV1', '~> 3.5.0'
-    pod 'NVActivityIndicatorView'
+    pod 'NVActivityIndicatorView', '~> 4.8.0'
 
     post_install do |installer|
         installer.pods_project.targets.each do |target|


### PR DESCRIPTION
This prevents the app picking up breaking changes in version 5.x and beyond by specifying a version
within the 4.x version family.

[NVActivityIndicatorView released the 5.0.0 version a few months ago](https://github.com/ninjaprox/NVActivityIndicatorView/releases/tag/5.0.0), which removes the `NVActivityIndicatorViewable` protocol. This introduces build errors with the application, as the `Podfile` does not specify a version of the pod, which results in picking the latest version.